### PR TITLE
feat: Swagger 설정 및 API 문서화 (Playlist, Music, Letter)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     //    security
+    // security
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -32,6 +33,10 @@ dependencies {
     implementation("org.springframework.session:spring-session-core")
 
     //    mapper
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+
+    // mapper
     implementation("org.mapstruct:mapstruct:1.5.5.Final")
     kapt("org.mapstruct:mapstruct-processor:1.5.5.Final")
     kapt("org.projectlombok:lombok-mapstruct-binding:0.2.0")

--- a/src/main/kotlin/com/cymply/auth/config/OAuth2LoginSecurityConfig.kt
+++ b/src/main/kotlin/com/cymply/auth/config/OAuth2LoginSecurityConfig.kt
@@ -27,7 +27,7 @@ class OAuth2LoginSecurityConfig(
             .csrf { it.disable() }
             .cors { CorsConfig().corsConfigurationSource() }
             .authorizeHttpRequests {
-                it.requestMatchers("/", "/oauth2/**", "/api/public/**")
+                it.requestMatchers("/", "/oauth2/**", "/api/public/**", "/swagger-ui/**", "/api-docs/**", "/api/v1/**")
                     .permitAll().anyRequest().authenticated()
             }
             .formLogin { it.disable() }

--- a/src/main/kotlin/com/cymply/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/cymply/common/config/SwaggerConfig.kt
@@ -1,0 +1,63 @@
+package com.cymply.common.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    private val securitySchemeName = "JWT Authorization"
+
+    @Bean
+    fun openAPI(): OpenAPI =
+        OpenAPI()
+            .info(getInfo())
+            .addSecurityItem(getSecurityRequirement())
+            .components(Components().addSecuritySchemes(securitySchemeName, getSecurityScheme()))
+
+//    @Bean
+//    fun sortSchemas(): OpenApiCustomizer = OpenApiCustomizer { openApi: OpenAPI ->
+//        val components: Components = openApi.components ?: Components().also { openApi.components = it }
+//
+//        val originalSchemas: Map<String, io.swagger.v3.oas.models.media.Schema<*>> =
+//            components.schemas ?: emptyMap()
+//
+//        if (originalSchemas.isNotEmpty()) {
+//            val sorted: SortedMap<String, Schema<*>> = TreeMap()
+//            sorted.putAll(originalSchemas)
+//
+//            components.schemas = sorted
+//        }
+//    }
+
+    private fun getInfo(): Info =
+        Info()
+            .title("Cymply API")
+            .description("Cymply Demo Server Swagger")
+            .contact(getContact())
+            .version("0.0.1")
+
+    private fun getContact(): Contact =
+        Contact()
+            .name("Github Repository")
+            .url("https://github.com/Cymply/cymply-be")
+            .email("cymply.official25@gmail.com")
+
+    private fun getSecurityRequirement(): SecurityRequirement =
+        SecurityRequirement().addList(securitySchemeName)
+
+    private fun getSecurityScheme(): SecurityScheme =
+        SecurityScheme()
+            .name(securitySchemeName)
+            .type(SecurityScheme.Type.HTTP)
+            .`in`(SecurityScheme.In.HEADER)
+            .scheme("Bearer")
+            .bearerFormat("JWT")
+
+}

--- a/src/main/kotlin/com/cymply/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/cymply/common/response/ApiResponse.kt
@@ -1,0 +1,61 @@
+package com.cymply.common.response
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "공통 API 응답 모델")
+data class ApiResponse<T>(
+
+    @field:Schema(description = "성공 여부")
+    val success: Boolean,
+
+    @field:Schema(description = "응답 데이터")
+    val data: DataWrapper<T>? = null,
+
+    @field:Schema(description = "에러 메시지")
+    val errorMessage: String? = null
+) {
+
+    @Schema(description = "응답 데이터 래퍼")
+    data class DataWrapper<T>(
+
+        @field:Schema(description = "응답 데이터 내용")
+        val content: T,
+
+        @field:Schema(description = "페이징")
+        val pagination: Pagination? = null
+    )
+
+    @Schema(description = "페이지 정보 DTO")
+    data class Pagination(
+
+        @field:Schema(description = "현재 페이지")
+        val page: Int,
+
+        @field:Schema(description = "페이지별 데이터 수")
+        val size: Int,
+
+        @field:Schema(description = "전체 페이지 수")
+        val totalPages: Int,
+
+        @field:Schema(description = "전체 데이터 수")
+        val totalElements: Long
+    )
+
+    companion object {
+        fun <T> success(content: T, pagination: Pagination? = null): ApiResponse<T> =
+            ApiResponse(
+                success = true,
+                data = DataWrapper(content, pagination),
+                errorMessage = null
+            )
+
+        fun <T> failure(content: T, errorMessage: String? = null): ApiResponse<T> =
+            ApiResponse(
+                success = false,
+                data = null,
+                errorMessage = errorMessage
+            )
+    }
+}

--- a/src/main/kotlin/com/cymply/letter/adapter/in/web/controller/LetterApiController.kt
+++ b/src/main/kotlin/com/cymply/letter/adapter/in/web/controller/LetterApiController.kt
@@ -1,0 +1,67 @@
+package com.cymply.letter.adapter.`in`.web.controller
+
+import com.cymply.letter.adapter.`in`.web.dto.LetterResponse
+import com.cymply.letter.adapter.`in`.web.dto.SendLetterRequest
+import com.cymply.letter.adapter.`in`.web.dto.SenderGroupedLettersResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Letter", description = "편지 관련 API")
+@RequestMapping("/api/v1/letters")
+interface LetterApiController {
+
+    @Operation(summary = "편지 단건 조회", description = "편지 ID로 편지를 상세 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "성공",
+            ),
+            ApiResponse(responseCode = "404", description = "유효하지 않은 편지 ID")
+        ]
+    )
+    @GetMapping("/{id}")
+    fun getLetter(
+        @Parameter(
+            description = "조회하려는 편지의 ID",
+            example = "1000",
+            `in` = ParameterIn.PATH,
+        )
+        @PathVariable id: Long
+    ) : com.cymply.common.response.ApiResponse<LetterResponse>
+
+    @Operation(summary = "편지 전송", description = "특졍 사용자에게 편지를 보냅니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "성공",
+            ),
+            ApiResponse(responseCode = "404", description = "편지 전송 중 오류가 발생했습니다.")
+        ]
+    )
+    @PostMapping
+    fun sendLetter(
+        @RequestBody @Schema(implementation = SendLetterRequest::class) request: SendLetterRequest
+    ) : com.cymply.common.response.ApiResponse<Unit>
+
+    @Operation(summary = "받은 편지 목록", description = "받은 편지 목록을 확인합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "성공",
+            ),
+            ApiResponse(responseCode = "404", description = "편지 목록 예외")
+        ]
+    )
+    @GetMapping("/received/grouped")
+    fun getGroupedReceivedLetters(
+    ) : com.cymply.common.response.ApiResponse<List<SenderGroupedLettersResponse>>
+}

--- a/src/main/kotlin/com/cymply/letter/adapter/in/web/controller/LetterController.kt
+++ b/src/main/kotlin/com/cymply/letter/adapter/in/web/controller/LetterController.kt
@@ -1,0 +1,56 @@
+package com.cymply.letter.adapter.`in`.web.controller
+
+import com.cymply.common.response.ApiResponse
+import com.cymply.letter.adapter.`in`.web.dto.LetterResponse
+import com.cymply.letter.adapter.`in`.web.dto.SendLetterRequest
+import com.cymply.letter.adapter.`in`.web.dto.SenderGroupedLettersResponse
+import com.cymply.music.adapter.`in`.web.dto.MusicResponse
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping("/api/v1/letters")
+class LetterController: LetterApiController {
+
+    @GetMapping("/{id}")
+    override fun getLetter(
+        @PathVariable id: Long
+    ): ApiResponse<LetterResponse> {
+        return ApiResponse.success(LetterResponse(1L, "", "", LocalDateTime.now(), MusicResponse(1L, "", "", "")))
+    }
+
+    @PostMapping
+    override fun sendLetter(request: SendLetterRequest): ApiResponse<Unit> {
+        return ApiResponse.success(Unit)
+    }
+
+    @GetMapping("/received/grouped")
+    override fun getGroupedReceivedLetters(
+//        @RequestParam request: GetLettersRequest
+    ): ApiResponse<List<SenderGroupedLettersResponse>> {
+        return ApiResponse.success(listOf(SenderGroupedLettersResponse(1L, "", emptyList())))
+    }
+
+    /*
+
+    @GetMapping("/received")
+    fun getFlatReceivedLetters(
+        @RequestParam request: GetLettersRequest
+    ) {
+
+    }
+
+    @GetMapping("/sent/grouped")
+    fun getGroupedSentLetters(
+        @RequestParam request: GetLettersRequest
+    ) {
+
+    }
+
+    @GetMapping("/sent")
+    fun getFlatSentLetters(
+        @RequestParam request: GetLettersRequest
+    ) {
+
+    }*/
+}

--- a/src/main/kotlin/com/cymply/letter/adapter/in/web/dto/LetterResponse.kt
+++ b/src/main/kotlin/com/cymply/letter/adapter/in/web/dto/LetterResponse.kt
@@ -1,0 +1,24 @@
+package com.cymply.letter.adapter.`in`.web.dto
+
+import com.cymply.music.adapter.`in`.web.dto.MusicResponse
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "편지 상세 응답 DTO")
+data class LetterResponse(
+
+    @field:Schema(description = "편지 ID", example = "1000")
+    val id: Long,
+
+    @field:Schema(description = "발신자 닉네임", example = "홍길동")
+    val senderNickname: String,
+
+    @field:Schema(description = "편지 내용", example = "안녕 테스터!")
+    val content: String,
+
+    @field:Schema(description = "전송 시각 (ISO 8601 형식)", example = "2025-06-01T12:00:00")
+    val sentAt: LocalDateTime,
+
+    @field:Schema(implementation = MusicResponse::class)
+    val music: MusicResponse
+)

--- a/src/main/kotlin/com/cymply/letter/adapter/in/web/dto/SendLetterRequest.kt
+++ b/src/main/kotlin/com/cymply/letter/adapter/in/web/dto/SendLetterRequest.kt
@@ -1,0 +1,20 @@
+package com.cymply.letter.adapter.`in`.web.dto
+
+import com.cymply.music.adapter.`in`.web.dto.MusicRequest
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "편지 전송 요청 DTO")
+data class SendLetterRequest(
+
+    @field:Schema(description = "발신자 ID", example = "1000")
+    val sender: Long,
+
+    @Schema(description = "발신자 ID", example = "1000")
+    val receipt: Long,
+
+    @Schema(implementation = MusicRequest::class)
+    val music: MusicRequest,
+
+    @Schema(description = "편지 내용", example = "안녕 테스터!")
+    val content: String
+)

--- a/src/main/kotlin/com/cymply/letter/adapter/in/web/dto/SenderGroupedLettersResponse.kt
+++ b/src/main/kotlin/com/cymply/letter/adapter/in/web/dto/SenderGroupedLettersResponse.kt
@@ -1,0 +1,29 @@
+package com.cymply.letter.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "받은 편지 목록 그룹화 응답 DTO")
+data class SenderGroupedLettersResponse(
+
+    @field:Schema(description = "발신자 ID", example = "1000")
+    val senderId: Long,
+
+    @field:Schema(description = "발신자 닉네임", example = "홍길동")
+    val senderNickname: String,
+
+    @field:Schema(description = "특정 사용자에게서 받은 편지 목록")
+    val letters: List<LetterSummaryResponse>
+)
+
+@Schema(description = "편지 요약 응답 DTO")
+data class LetterSummaryResponse(
+
+    @field:Schema(description = "편지 ID", example = "1000")
+    val letterId: Long,
+
+    @field:Schema(description = "편지 요약 내용", example = "안녕 테스터!")
+    val content: String,
+
+    @field:Schema(description = "음악 ID", example = "1000")
+    val musicId: Long
+)

--- a/src/main/kotlin/com/cymply/music/adapter/in/web/controller/MusicApiController.kt
+++ b/src/main/kotlin/com/cymply/music/adapter/in/web/controller/MusicApiController.kt
@@ -1,0 +1,36 @@
+package com.cymply.music.adapter.`in`.web.controller
+
+import com.cymply.music.adapter.`in`.web.dto.MusicResponse
+import com.cymply.music.adapter.`in`.web.dto.MusicSearchRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "Music", description = "음악 관련 API")
+@RequestMapping("/api/v1/music")
+interface MusicApiController {
+
+    @Operation(
+        summary = "음악 검색",
+        description = "제목 또는 아티스트 이름으로 음악을 검색합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "성공",
+            ),
+            ApiResponse(responseCode = "404", description = "")
+        ]
+    )
+    @GetMapping("/search")
+    fun searchMusic(
+        @ParameterObject @RequestParam request: MusicSearchRequest
+    ) : com.cymply.common.response.ApiResponse<List<MusicResponse>>
+
+}

--- a/src/main/kotlin/com/cymply/music/adapter/in/web/controller/MusicController.kt
+++ b/src/main/kotlin/com/cymply/music/adapter/in/web/controller/MusicController.kt
@@ -1,0 +1,20 @@
+package com.cymply.music.adapter.`in`.web.controller
+
+import com.cymply.common.response.ApiResponse
+import com.cymply.music.adapter.`in`.web.dto.MusicResponse
+import com.cymply.music.adapter.`in`.web.dto.MusicSearchRequest
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/music")
+class MusicController : MusicApiController {
+
+    override fun searchMusic(
+        @RequestParam request: MusicSearchRequest
+    ): ApiResponse<List<MusicResponse>> {
+
+        return ApiResponse.success(emptyList())
+    }
+}

--- a/src/main/kotlin/com/cymply/music/adapter/in/web/dto/MusicRequest.kt
+++ b/src/main/kotlin/com/cymply/music/adapter/in/web/dto/MusicRequest.kt
@@ -1,0 +1,13 @@
+package com.cymply.music.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "음악 요청 DTO")
+data class MusicRequest(
+
+    @Schema(description = "음악 제목", example = "좋은 날")
+    val title: String,
+
+    @Schema(description = "음악 아티스트", example = "IU")
+    val artist: String
+)

--- a/src/main/kotlin/com/cymply/music/adapter/in/web/dto/MusicResponse.kt
+++ b/src/main/kotlin/com/cymply/music/adapter/in/web/dto/MusicResponse.kt
@@ -1,0 +1,19 @@
+package com.cymply.music.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "음악 상세 응답 DTO")
+data class MusicResponse(
+
+    @field:Schema(description = "음악 ID", example = "1000")
+    val id: Long,
+
+    @field:Schema(description = "음악 제목", example = "좋은 날")
+    val title: String,
+
+    @field:Schema(description = "음악 아티스트", example = "IU")
+    val artist: String,
+
+    @field:Schema(description = "음악 썸네일 url", example = "www.example.com")
+    val thumbnail: String,
+)

--- a/src/main/kotlin/com/cymply/music/adapter/in/web/dto/MusicSearchRequest.kt
+++ b/src/main/kotlin/com/cymply/music/adapter/in/web/dto/MusicSearchRequest.kt
@@ -1,0 +1,10 @@
+package com.cymply.music.adapter.`in`.web.dto
+
+data class MusicSearchRequest(
+    val keyword: String,
+    val type: MusicSearchType,
+)
+
+enum class MusicSearchType {
+    TITLE, ARTIST
+}

--- a/src/main/kotlin/com/cymply/playlist/adapter/in/web/controller/PlaylistApiController.kt
+++ b/src/main/kotlin/com/cymply/playlist/adapter/in/web/controller/PlaylistApiController.kt
@@ -1,0 +1,32 @@
+package com.cymply.playlist.adapter.`in`.web.controller
+
+import com.cymply.playlist.adapter.`in`.web.dto.CreatePlaylistRequest
+import com.cymply.playlist.adapter.`in`.web.dto.CreatePlaylistResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Playlist", description = "플레이리스트 관련 API")
+@RequestMapping("/api/v1/playlists")
+interface PlaylistApiController {
+
+    @Operation(summary = "플레이리스트 생성", description = "플레이리스트를 생성합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            ),
+            ApiResponse(responseCode = "400", description = "잘못된 요청")
+        ]
+    )
+    @PostMapping
+    fun createPlaylist(
+        @ParameterObject @RequestBody request: CreatePlaylistRequest
+    ) : com.cymply.common.response.ApiResponse<CreatePlaylistResponse>
+}

--- a/src/main/kotlin/com/cymply/playlist/adapter/in/web/controller/PlaylistController.kt
+++ b/src/main/kotlin/com/cymply/playlist/adapter/in/web/controller/PlaylistController.kt
@@ -1,0 +1,20 @@
+package com.cymply.playlist.adapter.`in`.web.controller
+
+import com.cymply.common.response.ApiResponse
+import com.cymply.playlist.adapter.`in`.web.dto.CreatePlaylistRequest
+import com.cymply.playlist.adapter.`in`.web.dto.CreatePlaylistResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/playlists")
+class PlaylistController() : PlaylistApiController {
+
+    @PostMapping
+    override fun createPlaylist(request: CreatePlaylistRequest): ApiResponse<CreatePlaylistResponse> {
+        return ApiResponse.success(CreatePlaylistResponse(1L, "J-POP"))
+    }
+
+
+}

--- a/src/main/kotlin/com/cymply/playlist/adapter/in/web/dto/CreatePlaylistRequest.kt
+++ b/src/main/kotlin/com/cymply/playlist/adapter/in/web/dto/CreatePlaylistRequest.kt
@@ -1,0 +1,10 @@
+package com.cymply.playlist.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "플레이리스트 생성 요청 DTO")
+data class CreatePlaylistRequest(
+
+    @field:Schema(description = "플레이리스트 제목", example = "J-POP 모음")
+    val title: String
+)

--- a/src/main/kotlin/com/cymply/playlist/adapter/in/web/dto/CreatePlaylistResponse.kt
+++ b/src/main/kotlin/com/cymply/playlist/adapter/in/web/dto/CreatePlaylistResponse.kt
@@ -1,0 +1,13 @@
+package com.cymply.playlist.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "플레이리스트 생성 응답 DTO")
+data class CreatePlaylistResponse(
+
+    @field:Schema(description = "플레이리스트 ID", example = "1000")
+    val id: Long,
+
+    @field:Schema(description = "플레이리스트 제목", example = "J-POP 모음")
+    val title: String
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,19 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+springdoc:
+  swagger-ui:
+#    disable-swagger-default-url: true   #디폴트 페이지 안나오게
+#    display-request-duration: true
+#    operations-sorter: method
+#    tags-sorter: alpha
+    path: /api-ui.html
+    url: /api-docs    # 👈 반드시 이거!
+  api-docs:
+    path: /api-docs
+#  show-actuator: true
+#  default-consumes-media-type: application/json
+#  default-produces-media-type: application/json
+  model-converters:
+    generic-model-name-resolution-enabled: false


### PR DESCRIPTION
# feat: Swagger 설정 및 API 문서화 (Playlist, Music, Letter)

## 변경 사항
> 프로젝트 전반에 걸쳐 Swagger(OpenAPI) 연동과 공통 응답 객체(ApiResponse)를 도입하고, Playlist/Music/Letter 관련 API에 Swagger 애노테이션을 적용하여 API 문서를 자동 생성하도록 변경하였습니다.


- **Swagger 기본 설정 추가 및 공통 응답 객체(ApiResponse) 생성**
  - `SwaggerConfig.kt` 생성  
    - Springdoc(OpenAPI) 기반 Swagger UI 경로(`/api-ui.html`) 및 API 문서 경로(`/api-docs`) 설정  
    - JWT 인증(Authorization) 기능을 위한 `@SecurityScheme` 설정 포함  

- **Playlist 관련 API Swagger 적용**
  - `PlaylistsController.kt` 및 DTO 생성  
  - `@Tag(name = "Playlist", description = "플레이리스트 관련 API")` 추가 

- **Music 관련 API Swagger 적용**
  - `MusicController.kt` 및 DTO 생성  
  - `@Tag(name = "Music", description = "음악 관련 API")` 추가 

- **Letter 관련 API Swagger 적용**
  - `LetterController.kt` 및 DTO 생성  
  - `@Tag(name = "Letter", description = "편지 관련 API")` 추가 

- **application.yml 수정**
  - Swagger UI 접속 경로(`/api-ui.html`) 및 API 문서 경로(`/api-docs`) 지정

---

## 검토 포인트

1. **Swagger UI 접속 및 API 스펙 노출**  
   - `http://localhost:8080/api-ui.html` 에 접속하여 Playlist/Music/Letter 탭이 정상 생성되는지 확인  
   - 각 엔드포인트가 원하는 스펙대로 문서화되었는지 확인  

2. **공통 응답(`ApiResponse<T>`) 스키마 확인**  
   - `success`, `data.content`, `data.pagination`, `errorMessage` 필드가 올바르게 보이는지  
   - 제네릭 타입(`LetterResponse`, `CreatePlaylistResponse`, `MusicResponse` 등)이 스키마에 반영되는지  

3. **엔드포인트별 Example Value**  
   - DTO 클래스에 `@Schema(example = "...")`가 제대로 적용되어, Swagger UI 예시 JSON이 직관적으로 보이는지 확인  

4. **JWT 인증 (“Authorize” 버튼) 동작 여부**  
   - Swagger UI 상단 “Authorize” 클릭 시 `bearerAuth` 스키마가 노출되는지 확인  
   - 보호된 API(인증 필요) 엔드포인트에 정상적으로 JWT 토큰을 입력해 호출 가능한지 확인  


---

## 리팩토링 필요 항목
- Swagger UI Schema 에 응답 객체가 공통 응답 객체와 겹쳐 나오는 현상 수정   
<img width="448" alt="image" src="https://github.com/user-attachments/assets/6ec74ce8-2c48-4048-b4e0-3a89405fe32e" />   

- Security 관련 API 스펙 작성 (JWT 구현 이후 협의 필요)
- ErrorResponse 정의 필요
- Swagger Response 확인 시 데이터가 null 값인 경우 `null` 또는 노출되지 않도록 수정
